### PR TITLE
Account for keys that have a forward slash

### DIFF
--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -130,6 +130,22 @@ describe( "yaml-patch", ( ) =>
 
 			expect( res ).toMatchSnapshot( );
 		} );
+
+    it( "add string with slash in key", ( ) =>
+    {
+      const res = yamlPatch(
+        `a: String a`,
+        [
+          {
+            op: 'add',
+            path: '/b~1b',
+            value: 'String b/b',
+          }
+        ]
+      );
+
+      expect( res ).toBe( `a: String a\nb/b: String b/b\n` );
+    } );
 	} );
 
 	describe( "errors", ( ) =>

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -19,6 +19,11 @@ interface ParsedPath
 	pathTo: ( index: number ) => string;
 }
 
+// same function as found in the rfc6902 package: https://github.com/chbrown/rfc6902/blob/master/pointer.ts
+function unescape(token: string): string {
+  return token.replace(/~1/g, '/').replace(/~0/g, '~')
+}
+
 function traverse( root: NodeType, op: string, path: string ): ParsedPath
 {
 	const segments = path.split( '/' ).slice( 1 );
@@ -29,7 +34,7 @@ function traverse( root: NodeType, op: string, path: string ): ParsedPath
 		'/' +
 		segments.slice( 0, index === -1 ? undefined : index ).join( '/' );
 
-	const last = segments.pop( )!;
+  const last = unescape(segments.pop( )!);
 
 	let parent = root as YAMLMap | YAMLSeq;
 


### PR DESCRIPTION
It looks like the `rfc6902` package escapes keys with a forward slash in them so that it does not affect the path calculation. From my testing it looks like this is getting written back to YAML with that escaping still embedded. This PR hopefully works around that but using the same `unescape` function when the last key in a path is looked at.

Unfortunately it doesn't look like the rfc6902 package exports that unescape function so I just recreated it here.

It might make sense to have some of the fixtures have a forward slash in the key as opposed to the one-off test I put in. I was receiving an error on the fixtures tests hence why I put a test in the "various" category.