### PR TITLE
Accept ToStringOptions as last parameter in each method

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This package exports three functions: `yamlPatch`, `yamlDiffPatch` and `yamlOver
 ## yamlPatch
 
 ```ts
-function yamlPatch( yaml: string, rfc6902: Array< Operation > ): string;
+function yamlPatch( yaml: string, rfc6902: Array< Operation >, options?: ToStringOptions ): string;
 ```
 
 This function applies `<rfc6902>` *"JSON Patch"* operations on a `<yaml>` while trying to preserve whitespace, comments and structure for a minimal change.
@@ -42,7 +42,7 @@ You can use the [`rfc6902`][rfc6902-npm-url] package do create the patch object,
 ## yamlDiffPatch
 
 ```ts
-function yamlDiffPatch( yaml: string, oldJson: any, newJson: any ): string;
+function yamlDiffPatch( yaml: string, oldJson: any, newJson: any, options?: ToStringOptions ): string;
 ```
 
 Uses two JSON's (`<oldJson>` and `<newJson>`) and makes a diff between them, then applies this as a patch to the `<yaml>`.
@@ -55,7 +55,7 @@ This is the same as `yamlPatch( yaml, makeJsonPatch( oldJson, newJson ) );` wher
 ## yamlOverwrite
 
 ```ts
-function yamlOverwrite( yaml: string, newJson: any ): string;
+function yamlOverwrite( yaml: string, newJson: any, options?: ToStringOptions ): string;
 ```
 
 Uses the source `<yaml>` as the source object and diffs that against `<newJson>`, then applies this diff as a patch to the `<yaml>`. This will overwrite the fields that are different, while maintaining the structure of the source YAML.

--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -420,7 +420,7 @@ describe( "yaml-patch", ( ) =>
 			expect( result ).toBe( `a: ${line}\n` );
 		} );
 
-		it.skip( "keep long lines of array contenet", ( ) =>
+		it.skip( "keep long lines of array content", ( ) =>
 		{
 			const line = [
 				"This is an array element.", "This is an array element.",
@@ -437,6 +437,28 @@ describe( "yaml-patch", ( ) =>
 			);
 
 			expect( result ).toBe( `a: [ ${line} ]\n` );
+		} );
+	} );
+
+	describe( "options", ( ) =>
+	{
+		it.skip( "keep long lines of text if lineWidth is set to 0", ( ) =>
+		{
+			const line = [
+				"This is a long line of txt. ", "This is a long line of txt. ",
+				"This is a long line of txt. ", "This is a long line of txt. ",
+				"This is markdown [Link to some long text somewhere else]",
+				"(https://www.verylonglines.foo/yadayadayadayada/very/long)",
+				" seems this line never ends",
+			].join( '' );
+
+			const result = yamlPatch(
+				`a: ${line}\n`,
+				[ ],
+				{ lineWidth: 0 }
+			);
+
+			expect( result ).toBe( `a: ${line}\n` );
 		} );
 	} );
 } );

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,5 @@
 import { compare, Operation, unescapePathComponent } from 'fast-json-patch'
-import { parse, ParsedNode, parseDocument, Scalar } from 'yaml'
+import { parse, ParsedNode, parseDocument, Scalar, ToStringOptions } from 'yaml'
 import { Pair, YAMLMap, YAMLSeq } from 'yaml'
 
 export type {
@@ -13,6 +13,8 @@ export type {
 	TestOperation,
 	Operation,
 } from 'fast-json-patch'
+
+export type { ToStringOptions };
 
 import {
 	NodeType,
@@ -252,7 +254,7 @@ function applySinglePatch( root: ParsedNode, operation: Operation )
 	}
 }
 
-export function yamlPatch( yaml: string, rfc6902: Array< Operation > ): string
+export function yamlPatch( yaml: string, rfc6902: Array< Operation >, options?: ToStringOptions ): string
 {
 	const doc = parseDocument( yaml, {
 		keepSourceTokens: true,
@@ -285,17 +287,17 @@ export function yamlPatch( yaml: string, rfc6902: Array< Operation > ): string
 		}
 	} );
 
-	return doc.toString( );
+	return doc.toString( options );
 }
 
-export function yamlDiffPatch( yaml: string, oldJson: any, newJson: any )
+export function yamlDiffPatch( yaml: string, oldJson: any, newJson: any, options?: ToStringOptions )
 : string
 {
-	return yamlPatch( yaml, compare( oldJson, newJson ) );
+	return yamlPatch( yaml, compare( oldJson, newJson ), options );
 }
 
-export function yamlOverwrite( yaml: string, newJson: any ): string
+export function yamlOverwrite( yaml: string, newJson: any, options?: ToStringOptions ): string
 {
 	const old = parse( yaml );
-	return yamlDiffPatch( yaml, old, newJson );
+	return yamlDiffPatch( yaml, old, newJson, options );
 }


### PR DESCRIPTION
I thought about setting `lineWidth` to `0` by default to fix #4 but this has the side-effect of removing line breaks automatically which might not be desired. Instead I thought exposing a way to set the stringify options is better than nothing for now. At least this helps making this usuable for my current use-case.