### PR TITLE
Fix escaping below the top level of path

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -53,7 +53,7 @@ function traverse( root: ParsedNode, op: string, path: string ): ParsedPath
 			parent = parent.get( parseInt( segment ), true ) as
 				unknown as YAMLCollection;
 		else
-			parent = parent.get( segment, true ) as
+			parent = parent.get( unescapePathComponent( segment ), true ) as
 				unknown as YAMLCollection;
 
 		if ( !isYamlMap( parent ) && !isYamlSeq( parent ) )


### PR DESCRIPTION
Follow-on to https://github.com/grantila/yaml-diff-patch/pull/1 which only addressed top-level paths. Without this, it fails if there is an escaped segment deeper in the path.