### PR TITLE
Fix alias ordering error

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -285,7 +285,7 @@ export function yamlPatch( yaml: string, rfc6902: Array< Operation > ): string
 		}
 	} );
 
-	return doc.toString( );
+	return doc.toString( { verifyAliasOrder: false } );
 }
 
 export function yamlDiffPatch( yaml: string, oldJson: any, newJson: any )


### PR DESCRIPTION
I encountered an error because a yaml anchor was not detected before its reference in `YAML`'s `document.toString()`. This wasn't because of an error in the yaml document at hand, but just because of the representation passed to the YAML library (which only gets one part at a time) so this verification should not take place by default. 

Note this would conflict with https://github.com/grantila/yaml-diff-patch/pull/5; if you choose to merge that PR, this should have the options merged in.