### PR TITLE
JSON path ~ escape conversion

### DIFF
--- a/fixtures/slide-in-field.yaml
+++ b/fixtures/slide-in-field.yaml
@@ -1,0 +1,14 @@
+/foo/bar:
+  value: original
+
+---
+
+patch:
+  - op: replace
+    path: /~1foo~1bar/value
+    value: replaced
+
+---
+
+/foo/bar:
+  value: replaced

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -49,6 +49,9 @@ function traverse( root: ParsedNode, op: string, path: string ): ParsedPath
 
 	segments.forEach( ( segment, index ) =>
 	{
+		// escape ~1 with / and ~0 with ~, because the JSON patch uses
+		// ~1 and ~0 to escape slashes and tildes in the path.
+		segment = unescapePathComponent( segment );
 		if ( isYamlSeq( parent ) )
 			parent = parent.get( parseInt( segment ), true ) as
 				unknown as YAMLCollection;


### PR DESCRIPTION
When a YAML key contains a '/', the JSON patch specification uses the escaped string '~1' to represent this character. However, while traversing the YAML tree, **YAML compares keys using string equality**. Therefore, we need to **unescape the JSON path** (i.e., convert '~1' back to '/') before retrieving the corresponding YAML item.